### PR TITLE
Fix: force page refresh after anonymous post/reply to ensure privacy

### DIFF
--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -102,6 +102,7 @@ define('quickreply', [
 				storage.removeItem(qrDraftId);
 				QuickReply._autocomplete.hide();
 				hooks.fire('action:quickreply.success', { data });
+				ajaxify.refresh();
 			});
 		});
 

--- a/vendor/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/vendor/nodebb-plugin-composer-default/static/lib/composer.js
@@ -813,6 +813,8 @@ define('composer', [
 						(ajaxify.data.template.topic && parseInt(postData.tid, 10) !== parseInt(ajaxify.data.tid, 10)))
 					) {
 						ajaxify.go('post/' + data.pid);
+					} else {
+						ajaxify.refresh();
 					}
 				} else {
 					removeComposerHistory();


### PR DESCRIPTION
**Description:**
Currently, when a user creates an anonymous post or reply, the UI does not immediately reflect the anonymous state on the author's end without a manual refresh. This PR implements an automatic page refresh upon successful submission to ensure the user’s identity is correctly hidden in the view.

Changes: Added a page reload trigger following successful anonymous submission in file public/src/modules/quickreply.js.

Impact: Prevents UX confusion and ensures privacy states are rendered correctly for the poster.

**Testing:**
1. npm run lint
2. npm run test


Fix #39 